### PR TITLE
Add support for ATmega162

### DIFF
--- a/src/PinChangeInterrupt.cpp
+++ b/src/PinChangeInterrupt.cpp
@@ -163,6 +163,8 @@ void enablePinChangeInterruptHelper(const uint8_t pcintPort, const uint8_t pcint
 	// PCICR: Pin Change Interrupt Control Register - enables interrupt vectors
 #ifdef PCICR
 	PCICR |= (1  << (pcintPort + PCIE0));
+#elif defined(GICR) /* e.g. ATmega162 */
+	GICR |= (1  << (pcintPort + PCIE0));
 #elif defined(GIMSK) && defined(PCIE0) /* e.g. ATtiny X4 */
 	GIMSK |= (1  << (pcintPort + PCIE0));
 #elif defined(GIMSK) && defined(PCIE) /* e.g. ATtiny X5 */
@@ -240,6 +242,8 @@ void disablePinChangeInterruptHelper(const uint8_t pcintPort, const uint8_t pcin
 	{
 #ifdef PCICR
 		PCICR &= ~(1  << (pcintPort + PCIE0));
+#elif defined(GICR) /* e.g. ATmega162 */
+		GICR &= ~(1  << (pcintPort + PCIE0));
 #elif defined(GIMSK) && defined(PCIE0) /* e.g. ATtiny X4 */
 		GIMSK &= ~(1  << (pcintPort + PCIE0));
 #elif defined(GIMSK) && defined(PCIE) /* e.g. ATtiny X5 */

--- a/src/PinChangeInterruptBoards.h
+++ b/src/PinChangeInterruptBoards.h
@@ -36,6 +36,11 @@ THE SOFTWARE.
 #define PCINT_INPUT_PORT1 PINC
 #define PCINT_INPUT_PORT2 PIND
 
+#elif defined(__AVR_ATmega162__)
+
+#define PCINT_INPUT_PORT0 PINA
+#define PCINT_INPUT_PORT1 PINC
+
 #elif defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega640__)
 // Arduino Mega/Mega2560
 #define PCINT_INPUT_PORT0 PINB


### PR DESCRIPTION
It seems ATmega162 uses different Interrupt Control Register name, than the newer ATmega MCUs.