### PR TITLE
Add link to enable extra pin change ints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,7 @@ void PinChangeInterruptEvent(5)(void) {
 PinchangeInterrupt Table
 ========================
 Pins with * are not broken out/deactivated by default.
-You may activate them in the setting file (advanced).
+You may activate them in the setting file (comment out [this line](https://github.com/NicoHood/PinChangeInterrupt/blob/master/src/PinChangeInterruptSettings.h#L228)).
 
 Each row section represents a port(0-3).
 Not all MCUs have all Ports/Pins physically available.


### PR DESCRIPTION
I've been using the ATtiny84 and hit a hard bump when your lib didn't enable PCINTs on PCINT8 (physical pin 2) on the ATtiny84. I finally saw this footnote, and it took me awhile to figure out where it resided. This is just a small change to help folks more quickly locate the line of code in your lib to enable the additional interrupts.

I also recommend enabling these interrupts (8/9/10/11) by default but I understand the constraints (xtal, reset, etc).