### PR TITLE
ATMega328PB support

### DIFF
--- a/src/PinChangeInterruptBoards.h
+++ b/src/PinChangeInterruptBoards.h
@@ -30,11 +30,15 @@ THE SOFTWARE.
 
 // Microcontroller specific definitions
 
-#if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega88__)
+#if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega88__)
 // Arduino Uno
 #define PCINT_INPUT_PORT0 PINB
 #define PCINT_INPUT_PORT1 PINC
 #define PCINT_INPUT_PORT2 PIND
+
+#if defined(__AVR_ATmega328PB__)
+#define PCINT_INPUT_PORT3 PINE
+#endif
 
 #elif defined(__AVR_ATmega162__)
 


### PR DESCRIPTION
the ATMega328PB has an extra port, E. This PR adds support for this
port.

I have tested it with a Polulu A-Star 328PB with this board definition
file: https://github.com/pololu/a-star/blob/master/variants/a-star328pb/pins_arduino.h

Thanks for this library, it has saved a lot of legwork and works really
well.