### PR TITLE
Working with ATtinyx61

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -22,6 +22,7 @@ disablePCINT	KEYWORD2
 disablePinChangeInterrupt	KEYWORD2
 getPCINTTrigger	KEYWORD2
 getPinChangeInterruptTrigger	KEYWORD2
+initPinChangeInterrupt	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)

--- a/src/PinChangeInterrupt.cpp
+++ b/src/PinChangeInterrupt.cpp
@@ -165,6 +165,13 @@ void enablePinChangeInterruptHelper(const uint8_t pcintPort, const uint8_t pcint
 	PCICR |= (1  << (pcintPort + PCIE0));
 #elif defined(GICR) /* e.g. ATmega162 */
 	GICR |= (1  << (pcintPort + PCIE0));
+#elif defined(GIMSK) && (defined(__AVR_ATtiny261__) || defined(__AVR_ATtiny461__) || defined(__AVR_ATtiny861__))
+	if (pcintPort == 1 && pcintMask < 16) {
+		GIMSK |= (1 << PCIE0);
+	}
+	else {
+		GIMSK |= (1 << PCIE1);
+	}
 #elif defined(GIMSK) && defined(PCIE0) /* e.g. ATtiny X4 */
 	GIMSK |= (1  << (pcintPort + PCIE0));
 #elif defined(GIMSK) && defined(PCIE) /* e.g. ATtiny X5 */

--- a/src/PinChangeInterrupt.h
+++ b/src/PinChangeInterrupt.h
@@ -107,6 +107,12 @@ PinChangeInterruptEventPCINT ## pcint PCINT_MACRO_BRACKETS
 #error MCU has no such a register
 #endif
 
+#if defined(__AVR_ATtiny261__) || defined(__AVR_ATtiny461__) || defined(__AVR_ATtiny861__)
+#define initPinChangeInterrupt() PCMSK0 = 0; PCMSK1 = 0
+#else
+#define initPinChangeInterrupt() 
+#endif
+
 // alias for shorter writing
 #define PCINTEvent(n) PinChangeInterruptEvent_Wrapper(n)
 #define digitalPinToPCINT digitalPinToPinChangeInterrupt

--- a/src/PinChangeInterrupt0.cpp
+++ b/src/PinChangeInterrupt0.cpp
@@ -36,8 +36,17 @@ THE SOFTWARE.
 void attachPinChangeInterrupt0(void) {
 	// fake function to make the IDE link this file
 }
+#ifdef PCINT_COMBINE_PORT01
+void attachPinChangeInterrupt1(void) {
+	// fake function to make the IDE link this file
+}
+#endif
 
+#ifdef PCINT_COMBINE_PORT01
+ISR(PCINT_vect) {
+#else
 ISR(PCINT0_vect) {
+#endif
 	// get the new and old pin states for port
 	uint8_t newPort = PCINT_INPUT_PORT0;
 
@@ -71,6 +80,42 @@ ISR(PCINT0_vect) {
 #else
 	PCINT_CALLBACK_PORT0
 #endif
+
+#ifdef PCINT_COMBINE_PORT01
+	// get the new and old pin states for port
+	newPort = PCINT_INPUT_PORT1;
+
+	// compare with the old value to detect a rising or falling
+	arrayPos = getArrayPosPCINT(1);
+	change = newPort ^ oldPorts[arrayPos];
+	rising = change & newPort;
+	falling = change & oldPorts[arrayPos];
+
+	// check which pins are triggered, compared with the settings
+	risingTrigger = rising & risingPorts[arrayPos];
+	fallingTrigger = falling & fallingPorts[arrayPos];
+	trigger = risingTrigger | fallingTrigger;
+
+	// save the new state for next comparison
+	oldPorts[arrayPos] = newPort;
+
+	// Execute all functions that should be triggered
+	// This way we can exclude a single function
+	// and the calling is also much faster
+	// We may also reorder the pins for different priority
+#if !defined(PCINT_CALLBACK_PORT1)
+	PCINT_CALLBACK(0, 8);
+	PCINT_CALLBACK(1, 9);
+	PCINT_CALLBACK(2, 10);
+	PCINT_CALLBACK(3, 11);
+	PCINT_CALLBACK(4, 12);
+	PCINT_CALLBACK(5, 13);
+	PCINT_CALLBACK(6, 14);
+	PCINT_CALLBACK(7, 15);
+#else
+	PCINT_CALLBACK_PORT1
+#endif
+#endif // PCINT_COMBINE_PORT01
 }
 
 #if defined(PCINT_API)
@@ -141,6 +186,57 @@ void PinChangeInterruptEventPCINT7(void) {
 	callbackPCINT7();
 }
 #endif
+
+#ifdef PCINT_COMBINE_PORT01
+#if (PCINT_USE_PCINT8 == true)
+volatile callback callbackPCINT8 = pcint_null_callback;
+void PinChangeInterruptEventPCINT8(void) {
+	callbackPCINT8();
+}
+#endif
+#if (PCINT_USE_PCINT9 == true)
+volatile callback callbackPCINT9 = pcint_null_callback;
+void PinChangeInterruptEventPCINT9(void) {
+	callbackPCINT9();
+}
+#endif
+#if (PCINT_USE_PCINT10 == true)
+volatile callback callbackPCINT10 = pcint_null_callback;
+void PinChangeInterruptEventPCINT10(void) {
+	callbackPCINT10();
+}
+#endif
+#if (PCINT_USE_PCINT11 == true)
+volatile callback callbackPCINT11 = pcint_null_callback;
+void PinChangeInterruptEventPCINT11(void) {
+	callbackPCINT11();
+}
+#endif
+#if (PCINT_USE_PCINT12 == true)
+volatile callback callbackPCINT12 = pcint_null_callback;
+void PinChangeInterruptEventPCINT12(void) {
+	callbackPCINT12();
+}
+#endif
+#if (PCINT_USE_PCINT13 == true)
+volatile callback callbackPCINT13 = pcint_null_callback;
+void PinChangeInterruptEventPCINT13(void) {
+	callbackPCINT13();
+}
+#endif
+#if (PCINT_USE_PCINT14 == true)
+volatile callback callbackPCINT14 = pcint_null_callback;
+void PinChangeInterruptEventPCINT14(void) {
+	callbackPCINT14();
+}
+#endif
+#if (PCINT_USE_PCINT15 == true)
+volatile callback callbackPCINT15 = pcint_null_callback;
+void PinChangeInterruptEventPCINT15(void) {
+	callbackPCINT15();
+}
+#endif
+#endif // PCINT_COMBINE_PORT01
 
 #endif // PCINT_API
 

--- a/src/PinChangeInterrupt1.cpp
+++ b/src/PinChangeInterrupt1.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #if defined(PCINT_ALINKAGE) && defined(PCINT_COMPILE_ENABLED_ISR) && defined(PCINT_INCLUDE_FROM_CPP) \
 	|| !defined(PCINT_ALINKAGE) || !defined(PCINT_COMPILE_ENABLED_ISR)
 
-#if (PCINT_USE_PORT1 == true)
+#if (PCINT_USE_PORT1 == true) && !defined(PCINT_COMBINE_PORT01)
 
 void attachPinChangeInterrupt1(void) {
 	// fake function to make the IDE link this file

--- a/src/PinChangeInterruptBoards.h
+++ b/src/PinChangeInterruptBoards.h
@@ -142,6 +142,7 @@ THE SOFTWARE.
 // PORTB has Reset, clock and SPI while PORTA has I2C and Analog Pins. We just enable all pins.
 #define PCINT_INPUT_PORT0 PINA
 #define PCINT_INPUT_PORT1 PINB
+#define PCINT_COMBINE_PORT01 1
 
 #else // Microcontroller not supported
 #error PinChangeInterrupt library does not support this MCU.


### PR DESCRIPTION
Updates for issue #39, tested working on an ATtiny861.

Had to merge PCINT0_vect and PCINT1_vect into the single available interrupt callback, PCINT_vect. I did this by merging the PCINT1 code into PCINT0 and only enabling it on the x61. Probably not the best way to do this as it duplicates code between PinChangeInterrupt0.cpp and PinChangeInterrupt1.cpp.

Added an initialization method to clear out interrupts in both PCMSK0 and PCMSK1 on ATtinyx61 as interrupts on all pins are enabled by default. It's really just a #define and does nothing on other devices.

The split between PCIE0 and PCIE1 isn't even, 0 does PCINT 8-11 and 1 does PCINT 0-7 and 12-15. In enablePinChangeInterruptHelper a manual range check is done so that PCIE0 is only used for the first 4 pins of port 1.

I left the digitalPinToPCINT method as is which means it will still not work. I tested using the pin definitions from ATtinyCore (PIN_PA0, ..., PIN_PB7) which can be used as inputs to attachPinChangeInterrupt directly.

My working test code:
```c++
#include <PinChangeInterrupt.h>

void pulse() {
  digitalWrite(PIN_PA7, !digitalRead(PIN_PA7));
}

void setup() {
  initPinChangeInterrupt();
  pinMode(PIN_PB3, INPUT_PULLUP);
  attachPCINT(PIN_PB3, pulse, CHANGE);

  pinMode(PIN_PA7, OUTPUT);
  digitalWrite(PIN_PA7, HIGH);
}

void loop() {
}
```

With this simple circuit:
![image](https://user-images.githubusercontent.com/1920516/123499523-1161db00-d5fd-11eb-9f4f-2b7d1c80ad5f.png)
